### PR TITLE
Regular expressions and wildcards in redirect links

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -127,6 +127,10 @@
             <trans-unit id="no-records-found">
                 <source>No redirects found.</source>
             </trans-unit>
+            
+            <trans-unit id="collisions-detected">
+                <source>The link '%s' conflicts with '%s'.</source>
+            </trans-unit>
 
             <trans-unit id="controller.action.add.record">
                 <source>Add Redirect</source>

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
             "KoninklijkeCollective\\MyRedirects\\": "Classes/"
         }
     },
+    
+    "require": {
+        "witrin/formal-theory": "1.1.0"
+    },
 
     "authors": [
         {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/links; type=options[Hash=0,Wildcard=1,Regular Expression=2]; label=Matching mode: Set how the link matching is done.
+matching_mode = 0


### PR DESCRIPTION
Add support for different matching modes:

 * `hash` uses hash to find a redirect link
 * `regex` allow regular expression in redirect links
 * `wildcard` allow wildcard expression in redirect links

The matching mode has to be set globally through the extension
option `matching_mode`.