### PR TITLE
[BUGFIX] removed lowercase conversion

### DIFF
--- a/Classes/Controller/RequestController.php
+++ b/Classes/Controller/RequestController.php
@@ -30,7 +30,6 @@ class RequestController
     public function redirectAction()
     {
         $path = GeneralUtility::getIndpEnv('TYPO3_SITE_SCRIPT');
-        $path = $this->getCharsetConverter()->conv_case('utf-8', $path, 'toLower');
         if (!empty($path)) {
             try {
                 $redirect = $this->getRedirectService()->queryByPathAndDomain(

--- a/Classes/Service/RedirectService.php
+++ b/Classes/Service/RedirectService.php
@@ -261,8 +261,6 @@ class RedirectService implements \TYPO3\CMS\Core\SingletonInterface
                 }
             }
             $url = HttpUtility::buildUrl($urlParts);
-            // Make sure the hash is case-insensitive
-            $url = strtolower($url);
             return sha1($url);
         }
 


### PR DESCRIPTION
Please remove lowercase conversion of URLs breaking adwords and analytics urls containing gclid=UpperLowerCaseSensitive

@see https://support.google.com/analytics/answer/2938246?hl=en