### PR TITLE
Use a default Frontendcontroller by PageId

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -14,15 +14,6 @@ class ConfigurationUtility
     const EXTENSION = 'my_redirects';
 
     /**
-     * @return integer
-     */
-    public static function getDefaultRootPageId()
-    {
-        $configuration = static::getConfiguration();
-        return (int)($configuration['defaultRootPageId'] ?: ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['rootpage_id'] ?: 1));
-    }
-
-    /**
      * Get configured excluded parameters to keep in redirect
      *
      * @return array


### PR DESCRIPTION
Loads correct TSFE based on the destination page ID, which will allow multiple site / domain configuration to respect the correct RealURL settings. Without this fix, only links for the "first domain" will be handled correctly.

Use some fallbacks to find the correct TSFE "default page ID" to use:
- use the target pid, if the link points to a page ID (either with `t3://` prefix or simply an "id")
- check if the current domain has a `sys_domain` record, and use it's pid
- fallback to extensions `defaultRootPageId` configuration
- last resort: realurl "rootpage_id" setting for `_DEFAULT`