### PR TITLE
Fixes DomainTreeRedirects migration on root_page_domain

### DIFF
--- a/Classes/Install/Updates/DomainTreeRedirects.php
+++ b/Classes/Install/Updates/DomainTreeRedirects.php
@@ -89,7 +89,7 @@ class DomainTreeRedirects extends \TYPO3\CMS\Install\Updates\AbstractUpdate
             $info = $this->getRootPageByDomain((int)$row['domain']);
             $updateQuery->set('pid', (int)$info['uid'], false);
             $updateQuery->set('domain', (int)$row['domain'], false);
-            $updateQuery->set('root_page_domain', $info['uid'] . '-' . $row['domain'], false);
+            $updateQuery->set('root_page_domain', $info['uid'] . '-' . $row['domain']);
 
             $databaseQueries[] = $updateQuery->getSQL();
             if ($updateQuery->execute()) {


### PR DESCRIPTION
Without quoting the string value, you get an UPDATE SET statements like:

```
UPDATE ... SET ...  `root_page_domain` = 911-26 ...
```

which translates to `885` (integer). The value needs to be quoted, or in QueryBuilder environment, added as a named parameter.

I am not sure where or how this "root_page_domain" parameter is used, this just seemed wrong when I ran the migration on my test site and I saw these kind of updates.