### PR TITLE
[BUGFIX] Show file's name for redirects targeting a file

### DIFF
--- a/Classes/Domain/Model/Redirect.php
+++ b/Classes/Domain/Model/Redirect.php
@@ -235,7 +235,7 @@ class Redirect extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
                         $destination = 'Page: ' . $urn['pageuid'];
                         break;
                     case LinkService::TYPE_FILE:
-                        $destination = 'File: ' . $urn['file'];
+                        $destination = 'File: ' . $urn['file']->getName();
                         break;
                     case LinkService::TYPE_RECORD:
                         $destination = 'Record: ' . ($urn['identifier'] ?? $urn['uid']);


### PR DESCRIPTION
When a redirect to a file was applied, in my_redirects' backend module an error 500 occured. Function getAbsoluteDestination() tried to output the whole file object, which caused this error. Now not the whole file object but only the name of the targeted file is listed in backend module.